### PR TITLE
DO NOT MERGE: AI translate prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ node_modules
 /public/css/master-*.less
 .jshintrc
 .DS_Store
+.env
 

--- a/app.js
+++ b/app.js
@@ -1,6 +1,11 @@
+require('dotenv').config();
+
 require('apostrophe')({
   shortName: 'a3-boilerplate',
   modules: {
+    '@apostrophecms/translation': {},
+    'deepl-provider': {},
+
     // Apostrophe module configuration
     // *******************************
     //

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1,0 +1,22 @@
+module.exports = {
+  extendMethods(self) {
+    return {
+      async localize(_super, req, draft, toLocale, options = { update: false }) {
+        const fromLocale = draft.aposLocale.split(':')[0];
+        await self.emit('beforeLocalized', req, draft, {
+          source: fromLocale,
+          target: toLocale,
+          options
+        });
+
+        const result = await _super(req, draft, toLocale, options);
+
+        await self.emit('afterLocalized', req, draft, result, {
+          source: fromLocale,
+          target: toLocale,
+          options
+        });
+      }
+    };
+  }
+};

--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -3,7 +3,7 @@ module.exports = {
     return {
       async localize(_super, req, draft, toLocale, options = { update: false }) {
         const fromLocale = draft.aposLocale.split(':')[0];
-        await self.emit('beforeLocalized', req, draft, {
+        await self.emit('beforeLocalize', req, draft, {
           source: fromLocale,
           target: toLocale,
           options
@@ -11,7 +11,7 @@ module.exports = {
 
         const result = await _super(req, draft, toLocale, options);
 
-        await self.emit('afterLocalized', req, draft, result, {
+        await self.emit('afterLocalize', req, draft, result, {
           source: fromLocale,
           target: toLocale,
           options

--- a/modules/@apostrophecms/i18n/index.js
+++ b/modules/@apostrophecms/i18n/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+  options: {
+    locales: {
+      en: {
+        label: 'English'
+      },
+      bg: {
+        label: 'Bulgarian',
+        prefix: '/bg'
+      }
+    }
+  }
+};

--- a/modules/@apostrophecms/module/index.js
+++ b/modules/@apostrophecms/module/index.js
@@ -1,0 +1,11 @@
+// Part of the core.
+module.exports = {
+  methods(self) {
+    return {
+      // Public API. See `translation` module for more details.
+      addTranslationProvider(provider) {
+        self.apos.translation.addProvider(self, provider);
+      }
+    };
+  }
+};

--- a/modules/@apostrophecms/translation/index.js
+++ b/modules/@apostrophecms/translation/index.js
@@ -1,0 +1,367 @@
+// Part of the core - `@apostrophecms/translation` module.
+const _ = require('lodash');
+
+module.exports = {
+  options: {
+    alias: 'translation',
+    enabled: true
+  },
+
+  init(self) {
+    self.providers = [];
+    self.enableBrowserData();
+  },
+
+  handlers(self) {
+    return {
+      // Translate the document.
+      '@apostrophecms/doc-type:beforeLocalized': {
+        // `draft` is the document to translate
+        // `source` is the locale to translate from
+        // `target` is the locale to translate to
+        // `options`
+        // - update: boolean
+        // - provider: ID of the provider to use, usually sent by
+        // the UI (not implemented yet)
+        async submitTranslation(req, draft, {
+          source, target, options
+        }) {
+          await self.submitTranslation(req, draft, {
+            source,
+            target,
+            options
+          });
+        }
+      },
+
+      // Manage the document translation meta. Set state to `finalized` if
+      // when appropriate, do not copy the meta to the published document.
+      '@apostrophecms/doc-type:beforePublished': {
+        async manageTranslationMeta(req, {
+          firstTime, draft, published
+        }) {
+          const meta = draft.aposTranslationMeta;
+          if (!meta || meta.state === 'finalized') {
+            return;
+          }
+
+          if (self.getProvider(draft.aposTranslationMeta?.provider.id)) {
+            return;
+          }
+
+          if (meta.state === 'translated') {
+            draft.aposTranslationMeta.state = 'finalized';
+          }
+          delete published.aposTranslationMeta;
+        }
+      }
+    };
+  },
+
+  methods(self) {
+    return {
+      getProvider(providerId) {
+        return self.providers.find(({ config }) => (
+          config.id === providerId
+        )) || self.providers[0];
+      },
+
+      // Public API. `submitTranslation` handler should be present in the module
+      // that wants to provide translations. It will be called with the
+      // following arguments:
+      // - req: the request object
+      // - source: the locale to translate from
+      // - target: the locale to translate to
+      // - data: the data to translate - array of objects with `text`, either
+      //   `path` or `id` (or both, `id` represents `field._id` if available)
+      //   properties.
+      //   - `text` is the text to translate
+      //   - `path` is the dot path to the field that contains the text, see
+      //     `apos.util.get()` for more details on the format.
+      //   - `_id` is `object._id` that contains the text, optional
+      //   - `metaType` e.g. area, widget, array, etc., optional.
+      //   - `type` is the field type.
+      // It should return an object with the following properties:
+      // - state: 'pending' or 'translated'
+      // - fields: array of objects with the following properties:
+      //   - `translated`: the translated text
+      //
+      // `provider` is an object with the following properties:
+      // - id: the provider ID
+      // - label: the provider label
+      // - instant: if true, the translation will be returned immediately,
+      //   otherwise the translation will be considered asynchronous. If skipped,
+      //   the translation will be considered synchronous (true by default).
+      //
+      // Usually this handler shouldn't be called directly, but through the
+      // the module's `addProvider(config)` method.
+      addProvider(module, provider) {
+        if (self.options.enabled === false) {
+          self.logDebug('add-provider-skip', 'Not enabled');
+          return;
+        }
+
+        self.providers.push({
+          submitHandler: module.submitTranslation,
+          config: provider
+        });
+      },
+
+      async submitTranslation(req, draft, {
+        source, target, options
+      }) {
+        // XXX investigate options.update and why it's "true".
+        if (self.options.enabled === false) {
+          self.logDebug(
+            req,
+            'before-localize-skip',
+            'Not enabled or update requested',
+            {
+              options,
+              enabled: self.options.enabled
+            }
+          );
+          return;
+        }
+
+        if (self.providers.length === 0) {
+          self.logDebug(req, 'before-localize-skip', 'No providers available');
+          return;
+        }
+
+        const provider = self.getProvider(options.provider);
+
+        if (!provider) {
+          throw self.apos.error('notfound', 'Provider not found');
+        }
+
+        const meta = self.getLocalizationMeta(req, draft, provider);
+        if (!meta.fields.length) {
+          self.logDebug(req, 'before-localize-skip', 'No fields to translate');
+          return;
+        }
+
+        self.logDebug(req, 'before-localize', {
+          source,
+          target,
+          meta
+        });
+        // We send a flat array of items with only `text` property and expect
+        // the same array back with translated `text` property.
+        const result = await provider
+          .submitHandler(req, {
+            source,
+            target,
+            data: meta
+          });
+
+        self.logDebug(req, 'before-apply', {
+          meta,
+          result
+        });
+
+        self.applyTranslation(req, draft, meta, result);
+
+        self.logDebug(req, 'after-localize', {
+          aposTranslationMeta: draft.aposTranslationMeta
+        });
+
+        await self.apos.notify(
+          req,
+            `Successfully translated ${result.fields.length} fields by ${meta.provider.label}.`,
+            {
+              type: 'success',
+              dismiss: false
+            }
+        );
+      },
+
+      // Fake stuff, just for prototyping, it's fairly more complicated than
+      // that (recursion, deep objects, arrays, etc.)
+      getLocalizationMeta(req, draft, provider) {
+        const result = {
+          version: '1.0',
+          state: 'pending',
+          provider: {
+            id: provider.config.id,
+            label: provider.config.label
+          },
+          fields: []
+        };
+
+        const manager = self.apos.doc.getManager(draft.type);
+        if (!manager) {
+          return result;
+        }
+
+        const schema = manager.schema;
+        for (const field of schema) {
+          if (!field.translate === false) {
+            continue;
+          }
+
+          const value = _.get(draft, field.name);
+          switch (field.type) {
+            case 'string':
+              result.fields.push({
+                path: field.name,
+                schemaPath: [ field.name ],
+                text: value,
+                metaType: 'string',
+                type: field.type
+              });
+              break;
+
+            case 'slug': {
+              const formatted = self.apos.util.slugify(
+                value.split('/').pop(),
+                { separator: ' ' }
+              );
+              result.fields.push({
+                path: field.name,
+                schemaPath: [ field.name ],
+                text: formatted,
+                metaType: 'string',
+                type: field.type
+              });
+              break;
+            }
+
+            case 'area': {
+              result.fields.push(...self.getRichTextFrom(value, [ field.name ]));
+              break;
+            }
+          }
+        }
+
+        return result;
+      },
+
+      // A naive implementation again, just for prototyping.
+      // It lacks validation, error handling, etc.
+      applyTranslation(req, draft, meta, translated) {
+        const manager = self.apos.doc.getManager(draft.type);
+        if (!manager) {
+          return;
+        }
+
+        const newMeta = {
+          ...meta,
+          ...translated,
+          fields: []
+        };
+
+        if (newMeta.state === 'pending') {
+          newMeta.fields = meta.fields;
+          draft.aposTranslationMeta = newMeta;
+          return;
+        }
+
+        for (const [ index, item ] of translated.fields.entries()) {
+          const field = meta.fields[index];
+          const oldText = self.apos.util.get(draft, field.path);
+
+          // Dirty, as it should be when prototyping.
+          if (field.type !== 'slug' && oldText !== field.text) {
+            self.logDebug(
+              req,
+              'apply-translation-skip',
+              'Skipping, source text has been changed',
+              {
+                documentText: oldText,
+                tranlateSource: field.text
+              }
+            );
+            continue;
+          }
+
+          if (!item.translated) {
+            self.logDebug(
+              req,
+              'apply-translation-skip',
+              'Skipping, no translation provided',
+              field
+            );
+            continue;
+          }
+
+          let value = item.translated;
+          switch (field.type) {
+            case 'slug': {
+              const prefix = oldText.split('/').slice(0, -1).join('/');
+              value = prefix + '/' + self.apos.util.slugify(value);
+              break;
+            }
+          }
+
+          self.apos.util.set(draft, field.path, value);
+
+          const metaField = {
+            ...item,
+            ...field
+          };
+          delete metaField.translated;
+          newMeta.fields.push(metaField);
+        }
+
+        // Can be migrated in the future to `aposTranslation` collection.
+        draft.aposTranslationMeta = newMeta;
+      },
+
+      // Example handler to extract widgets from an area. It's a modified
+      // version of the `@apostrophecms/area:richText()`.
+      // It's here to demonstrate how we can handle complex data structures
+      // via single string `path` identifiers.
+      getRichTextFrom(area, schemaPath) {
+        const winners = [];
+        if (!area || typeof area !== 'object') {
+          return winners;
+        }
+        self.apos.doc.walk(area, function (o, key, value, dotPath, ancestors) {
+          if (test(value)) {
+            winners.push(value);
+          }
+        });
+
+        return winners.map(({
+          _id, content, metaType, type
+        }) => ({
+          _id,
+          path: `@${_id}.content`,
+          // Keep only root field name,
+          // not important, widgets are identified by `_id` anyway.
+          schemaPath,
+          metaType,
+          type,
+          text: content
+        }));
+
+        function test(item) {
+          if (!item || typeof item !== 'object') {
+            return false;
+          }
+          if (!_.includes(self.apos.area.richTextWidgetTypes, item.type)) {
+            return false;
+          }
+          return true;
+        }
+      }
+    };
+  },
+
+  extendMethods(self) {
+    return {
+      getBrowserData(_super, req) {
+        const data = _super(req);
+        data.providers = self.providers
+          .map(({ config }) => ({
+            label: config.label,
+            id: config.id
+          }));
+        data.enabled = self.options.enabled && self.providers.length > 0;
+
+        return data;
+      }
+    };
+  }
+};

--- a/modules/deepl-provider/index.js
+++ b/modules/deepl-provider/index.js
@@ -1,0 +1,95 @@
+const deepl = require('deepl-node');
+
+module.exports = {
+  options: {
+    providerId: 'deepl',
+    providerLabel: 'DeepL',
+    apiSecret: process.env.DEEPL_API_SECRET || null,
+    translateOptions: {
+      preserveFormatting: true,
+      formality: 'less',
+      splitSentences: 'nonewlines',
+      tagHandling: 'html'
+    }
+  },
+
+  init(self) {
+    self.translator = new deepl.Translator(self.options.apiSecret);
+    self.addTranslationProvider({
+      id: self.options.providerId,
+      label: self.options.providerLabel
+      // It's true by default.
+      // instant: true,
+    });
+  },
+
+  methods(self) {
+    return {
+      async submitTranslation(req, {
+        source, target, data
+      }) {
+        const options = { ...self.options.translateOptions };
+
+        // Usage detection
+        const usage = await self.translator.getUsage();
+        if (usage.anyLimitReached()) {
+          self.logError('submit-translation', 'DeepL API limit reached');
+          throw self.apos.error('locked', 'DeepL API limit reached');
+        }
+
+        // Language detection
+        const sourceLanguages = await self.translator.getSourceLanguages();
+        const srcLang = sourceLanguages
+          .find(({ code }) => code.split('-')[0].toLowerCase() === source);
+        const targetLanguages = await self.translator.getTargetLanguages();
+        const trgLang = targetLanguages
+          .find(({ code }) => code.split('-')[0].toLowerCase() === target);
+
+        if (!srcLang) {
+          throw self.apos.error('invalid', `Source language "${source}" is not supported.`);
+        }
+        if (!trgLang) {
+          throw self.apos.error('invalid', `Target language "${target}" is not supported.`);
+        }
+
+        if (options.formality && !trgLang.supportsFormality) {
+          delete options.formality;
+        }
+
+        const { provider, fields } = data;
+        const texts = fields.map(({ text }) => text);
+
+        // A scenario with multiple providers, we could check the supported
+        // providers before proxying the request to the right one.
+        if (provider.id !== self.options.providerId) {
+          throw self.apos.error('invalid', 'Invalid translation provider');
+        }
+
+        self.logDebug(req, 'submit-translation-before', {
+          provider: self.options.providerId,
+          source: srcLang,
+          target: trgLang,
+          options
+        });
+
+        const translation = await self.translator
+          .translateText(texts, source, target, options);
+
+        self.logDebug(req, 'submit-translation-after', {
+          provider: self.options.providerId,
+          source,
+          target,
+          contentLength: texts.reduce((total, text) => total + text.length, 0)
+        });
+
+        return {
+          state: 'translated',
+          fields: fields.map((item, index) => ({
+            ...item,
+            translated: translation[index].text
+          }))
+        };
+      }
+    };
+  }
+};

--- a/modules/default-page/index.js
+++ b/modules/default-page/index.js
@@ -44,6 +44,13 @@ module.exports = {
             '@apostrophecms/video': {}
           }
         }
+      },
+      aposTranslationMeta: {
+        type: 'tmeta',
+        label: 'Translation meta debug',
+        help: 'It is here because apos needs field in ' +
+          'order to save our meta (it needs a core fix). It also showcases ' +
+          'the meta data saved in the DB for the need of the demo.'
       }
     },
     group: {
@@ -53,7 +60,24 @@ module.exports = {
           'title',
           'main'
         ]
+      },
+      debug: {
+        label: 'Debug',
+        fields: [
+          'aposTranslationMeta'
+        ]
       }
     }
+  },
+
+  init(self) {
+    self.apos.schema.addFieldType({
+      name: 'tmeta',
+      vueComponent: 'TranslationMetaField',
+      async convert(req, field, data, destination) {
+        destination[field.name] = data[field.name];
+      },
+      def: null
+    });
   }
 };

--- a/modules/default-page/ui/apos/components/TranslationMetaField.vue
+++ b/modules/default-page/ui/apos/components/TranslationMetaField.vue
@@ -1,0 +1,33 @@
+<template>
+  <AposInputWrapper
+    :modifiers="modifiers" :field="field"
+    :error="effectiveError" :uid="uid"
+    :display-options="displayOptions"
+  >
+    <template #body>
+      <pre>{{ jsonValue }}</pre>
+    </template>
+  </AposInputWrapper> 
+</template>
+
+<script> 
+import AposInputMixin from 'Modules/@apostrophecms/schema/mixins/AposInputMixin';
+
+export default {
+  name: 'TranslationMetaField',
+  mixins: [ AposInputMixin ],
+  computed: {
+    jsonValue() {
+      if (!this.value.data) {
+        return 'N/A';
+      }
+      return JSON.stringify(this.value.data, null, 2);
+    }
+  },
+  methods: {
+    validate(values) {
+      return false;
+    },
+  }
+}
+</script>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   "license": "MIT",
   "dependencies": {
     "apostrophe": "^3.53.0",
+    "deepl-node": "^1.11.0",
+    "dotenv": "^16.3.1",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary
> SHOULD NOT BE MERGED, it's only a prototype/demo.

A quick implementation, that showcases the translate API core architecture and a provider external module. In this PR:
- `@apostrophecms/translation` represents a core module, integration point for AI translation providers (external module).
- `deepl-provider` represents an external AI translation provider that integrates with the core translation API
-  `@apostrophecms/doc-type` enhances the core with the required event for page localization (should be core change) 
-  `@apostrophecms/module` adds the public registration handler for providers 
- `default-page` adds debug field type to demonstrate what meta information will be available to the admin UI
- adds some more utilities to handle the DeepL API secret as environment (see below)

## What are the specific steps to test this change?

- Install the dependencies via `npm install`
- create `.env` file in the project root and add `DEEPL_API_SECRET=xxx` where `xxx` is the API secret as seen in your DeepL account
- Create an admin user and run the app (`npm run dev`)

What happens?
- On init, the DeepL module registers itself as a translation provider.
- A user creates page of type "default-page"  and localizes it (extend `@apostrophecms/page` settings with any language you'd like) to existing locale. The prototype doesn't include any UI configuration ("Translate with ...), it translates by default and if enabled.
- The core translation module hooks via the `beforeLocalized` event, finds the (only) provider, extracts the translation meta data, sets the meta state to `pending`  and executes the provider's translation handler.
- The DeepL provider validates the REST availability of the service (quotas), detects if the languages involved are supported, adapts its predefined service configuration, makes a request, sets the meta state to `translated` and returns the translated data to the core.
- The core translation routine sets the translated values in the draft document. 
- Edit the localized document, verify "Title", "Slug" and "Main" area rich text widgets translation. Navigate to tag Debug to inspect what information is available in the admin UI. 
- After Publishing the page, the translation module sets the meta state to `finalized` (once) and prevents the meta to be copied to the published doc. Edit and verify in the debug tab the new and final state. Inspect the published document directly in the mongo database - `aposTranslationMeta` property shouldn't be found.

