### PR TITLE
demonstrate how to forbid certain slugs

### DIFF
--- a/modules/@apostrophecms/doc-type/index.js
+++ b/modules/@apostrophecms/doc-type/index.js
@@ -1,0 +1,28 @@
+console.log('loading');
+
+module.exports = {
+  options: {
+    forbiddenSlugs: [
+      '/evil-page',
+      'evil-piece'
+    ]
+  },
+  handlers(self) {
+    return {
+      beforeSave: {
+        checkForbiddenSlugs(req, doc) {
+          console.log(doc.slug);
+          if (self.options.forbiddenSlugs.includes(doc.slug)) {
+            const e = self.apos.error('invalid', 'That slug is reserved.');
+            e.path = 'slug';
+            throw self.apos.error('invalid', {
+              errors: [
+                e
+              ]
+            });
+          }
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
This PR on one of our basic starter kits demonstrates how to forbid certain slugs by generating an error on the server side. A `beforeSave` handler on `@apostrophecms/doc-type`, the base class of all doc type modules, is used to achieve the effect.