### PR TITLE
route to obtain frontend bundles

### DIFF
--- a/modules/asset/index.js
+++ b/modules/asset/index.js
@@ -7,5 +7,22 @@ module.exports = {
         }
       }
     };
+  },
+  apiRoutes(self) {
+    return {
+      get: {
+        bundleMarkup(req) {
+          let content = 'scripts\nstylesheets';
+          content = self.apos.template.insertBundlesMarkup({
+            scene: 'public',
+            content,
+            scriptsPlaceholder: 'scripts',
+            stylesheetsPlaceholder: 'stylesheets',
+            widgetsBundles: {}
+          });
+          return content;
+        }
+      }
+    };
   }
 };


### PR DESCRIPTION
An example of a route that returns markup that will load the needed JS and CSS if included in a page. This is needed when fusing Apostrophe's CSS and JS assets with an otherwise "headless" application.