### PR TITLE
removes all specific rich-text configs

### DIFF
--- a/lib/area.js
+++ b/lib/area.js
@@ -2,47 +2,5 @@ export default {
   '@apostrophecms/image': {},
   '@apostrophecms/video': {},
   '@apostrophecms/html': {},
-  '@apostrophecms/rich-text': {
-    toolbar: [
-      'styles',
-      '|',
-      'bold',
-      'italic',
-      'strike',
-      'link',
-      '|',
-      'bulletList',
-      'orderedList',
-      '|',
-      'blockquote',
-      'codeBlock',
-      '|',
-      'table',
-      'image',
-      '|',
-      'horizontalRule',
-      '|',
-      'undo',
-      'redo'
-    ],
-    styles: [
-      {
-        tag: 'p',
-        label: 'Paragraph (P)'
-      },
-      {
-        tag: 'h3',
-        label: 'Heading 3 (H3)'
-      },
-      {
-        tag: 'h4',
-        label: 'Heading 4 (H4)'
-      }
-    ],
-    insert: [
-      'table',
-      'importTable',
-      'image'
-    ]
-  }
+  '@apostrophecms/rich-text': {}
 };

--- a/modules/@apostrophecms/home-page/index.js
+++ b/modules/@apostrophecms/home-page/index.js
@@ -8,41 +8,7 @@ export default {
         type: 'area',
         options: {
           widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [
-                'styles',
-                '|',
-                'bold',
-                'italic',
-                'strike',
-                'link',
-                '|',
-                'bulletList',
-                'orderedList',
-                '|',
-                'table',
-                'image'
-              ],
-              styles: [
-                {
-                  tag: 'p',
-                  label: 'Paragraph (P)'
-                },
-                {
-                  tag: 'h3',
-                  label: 'Heading 3 (H3)'
-                },
-                {
-                  tag: 'h4',
-                  label: 'Heading 4 (H4)'
-                }
-              ],
-              insert: [
-                'table',
-                'importTable',
-                'image'
-              ]
-            },
+            '@apostrophecms/rich-text': {},
             '@apostrophecms/image': {},
             '@apostrophecms/video': {}
           }

--- a/modules/default-page/index.js
+++ b/modules/default-page/index.js
@@ -9,41 +9,7 @@ export default {
         type: 'area',
         options: {
           widgets: {
-            '@apostrophecms/rich-text': {
-              toolbar: [
-                'styles',
-                '|',
-                'bold',
-                'italic',
-                'strike',
-                'link',
-                '|',
-                'bulletList',
-                'orderedList',
-                '|',
-                'table',
-                'image',
-              ],
-              styles: [
-                {
-                  tag: 'p',
-                  label: 'Paragraph (P)'
-                },
-                {
-                  tag: 'h3',
-                  label: 'Heading 3 (H3)'
-                },
-                {
-                  tag: 'h4',
-                  label: 'Heading 4 (H4)'
-                }
-              ],
-              insert: [
-                'table',
-                'importTable',
-                'image'
-              ]
-            },
+            '@apostrophecms/rich-text': {},
             '@apostrophecms/image': {},
             '@apostrophecms/video': {}
           }


### PR DESCRIPTION
[PRO-7646](https://linear.app/apostrophecms/issue/PRO-7646/as-an-editor-i-want-multiple-headings-in-the-rich-text-toolbar-set-up)

## Summary

Remove all rich-text specific configs to use new default.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
