### PR TITLE
validation that passport bridge 1.5.0-beta.1 does not break more typical passport strategies configured the old fashioned way

### DIFF
--- a/apos.vite.config.js
+++ b/apos.vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from '@apostrophecms/vite/vite';
+
+export default defineConfig({
+  server: {
+    hmr: {
+      protocol: 'wss',
+      host: 'b75daf165449.ngrok.app',
+    },
+    origin: 'https://b75daf165449.ngrok.app',
+    cors: true,
+    strictPort: true
+  }
+});

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import apostrophe from 'apostrophe';
 apostrophe({
   root: import.meta,
   shortName: 'a4-boilerplate',
+  baseUrl: 'https://b75daf165449.ngrok.app',
   modules: {
     // Apostrophe module configuration
     // *******************************
@@ -34,6 +35,7 @@ apostrophe({
     // use vite for asset bundling and hot module reloading
     '@apostrophecms/vite': {},
     // The project's first custom page type.
-    'default-page': {}
+    'default-page': {},
+    '@apostrophecms/passport-bridge': {}
   }
 });

--- a/modules/@apostrophecms/home-page/views/page.html
+++ b/modules/@apostrophecms/home-page/views/page.html
@@ -8,7 +8,7 @@
 {% block main %}
   <section class="bp-welcome">
     <h1 class="bp-welcome__headline">
-      Welcome to ApostropheCMS
+      Welcome to ApostropheCMS, {{ data.user.title }}
     </h1>
     {% if not data.user %}
       {# Message only for logged out users. #}

--- a/modules/@apostrophecms/passport-bridge/index.js
+++ b/modules/@apostrophecms/passport-bridge/index.js
@@ -1,0 +1,30 @@
+export default {
+  options: {
+    // optional
+    create: {
+      role: 'guest'
+    },
+    strategies: [
+      {
+        // You must npm install --save this module in your project first
+        module: 'passport-google-oauth20',
+        options: {
+          // Options for passport-google-oauth20
+          clientID: process.env.GOOGLE_CLIENT_ID,
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET
+        },
+        // Ignore users whose email address does not match this domain
+        // according to the identity provider
+        emailDomain: 'apostrophecms.com',
+        // Use the user's email address as their identity
+        match: 'email',
+        // Strategy-specific options that must be passed to the authenticate middleware.
+        // See the documentation of the strategy module you are using
+        authenticate: {
+          // 'email' for the obvious, 'profile' for the displayName (for the create option)
+          scope: [ 'email', 'profile' ]
+        }
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
+    "@apostrophecms/passport-bridge": "apostrophecms/passport-bridge#pro-8013",
     "@apostrophecms/vite": "^1.0.0",
     "apostrophe": "^4.9.0",
-    "normalize.css": "^8.0.1"
+    "normalize.css": "^8.0.1",
+    "passport-google-oauth20": "^2.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
Nothing new here, the point is just that it still works.

I already tested this, but if you want to test it, be aware you need to use ngrok or similar to set up HTTPS for the apostrophecms site or google auth will say "nope."