### PR TITLE
Example of enabling guest access to the pages API

### DIFF
--- a/modules/@apostrophecms/express/index.js
+++ b/modules/@apostrophecms/express/index.js
@@ -3,6 +3,14 @@ export default {
     session: {
       // If this still says `undefined`, set a real secret!
       secret: undefined
+    },
+    apiKeys: {
+      // Use your own key value. Ideally use a strong, randomly generated
+      // key.
+      'testkey': {
+        // The user role associated with this key
+        role: 'guest'
+      }
     }
   }
 };

--- a/modules/@apostrophecms/page/index.js
+++ b/modules/@apostrophecms/page/index.js
@@ -3,6 +3,7 @@
 
 export default {
   options: {
+    guestApiAccess: true,
     types: [
       {
         name: 'default-page',


### PR DESCRIPTION
With these changes, this URL works:

http://localhost:3000/api/v1/@apostrophecms/page?apikey=testkey

Of course you can also use the authentication header in the manner described in the documentation.

*Do not merge, just a syntax example.*